### PR TITLE
Enable support for msbuild .net 2.0

### DIFF
--- a/msbuild-maven-plugin/src/main/java/uk/org/raje/maven/plugin/msbuild/AbstractMSBuildPluginMojo.java
+++ b/msbuild-maven-plugin/src/main/java/uk/org/raje/maven/plugin/msbuild/AbstractMSBuildPluginMojo.java
@@ -675,6 +675,8 @@ public abstract class AbstractMSBuildPluginMojo extends AbstractMojo
     /**
      * The value for 'maxcpucount' to pass to MSBuild.
      * Default value of -1 results in MSBuild being invoked with '/maxcpucount'.
+     * Value of 0 results in MSBuild being invoked without /maxcpucount 
+     * (useful for MSBuild that comes with .Net Framework v2, which doesn't support the maxcpucount param)
      */
     @Parameter(
             defaultValue = "-1",

--- a/msbuild-maven-plugin/src/main/java/uk/org/raje/maven/plugin/msbuild/MSBuildExecutor.java
+++ b/msbuild-maven-plugin/src/main/java/uk/org/raje/maven/plugin/msbuild/MSBuildExecutor.java
@@ -91,7 +91,7 @@ final class MSBuildExecutor
         {
             command.add( "/maxcpucount" );
         }
-        else
+        else if ( maxCpuCount > 0 )
         {
             command.add( "/maxcpucount:" + maxCpuCount );
         }

--- a/msbuild-maven-plugin/src/main/java/uk/org/raje/maven/plugin/msbuild/parser/BaseParser.java
+++ b/msbuild-maven-plugin/src/main/java/uk/org/raje/maven/plugin/msbuild/parser/BaseParser.java
@@ -83,7 +83,7 @@ abstract class BaseParser
      */
     public String getConfigurationPlatform() 
     {
-        return configuration + "|" + platform;
+        return configuration.replaceAll( "[ \t]" , "" ) + "|" + platform.replaceAll( "[ \t]" , "" );
     }
     
     /**

--- a/msbuild-maven-plugin/src/main/java/uk/org/raje/maven/plugin/msbuild/parser/VCSolutionParser.java
+++ b/msbuild-maven-plugin/src/main/java/uk/org/raje/maven/plugin/msbuild/parser/VCSolutionParser.java
@@ -173,7 +173,7 @@ class VCSolutionParser extends BaseParser
     
     private static String getPathPattern( String groupName ) 
     {
-        return "\"(?<" + groupName + ">.+\\.vcxproj)\"";
+        return "\"(?<" + groupName + ">.+\\..*proj)\"";
     }
     
     private enum SolutionParserState 

--- a/msbuild-maven-plugin/src/test/java/uk/org/raje/maven/plugin/msbuild/MSBuildMojoConfigurationTest.java
+++ b/msbuild-maven-plugin/src/test/java/uk/org/raje/maven/plugin/msbuild/MSBuildMojoConfigurationTest.java
@@ -198,6 +198,18 @@ public class MSBuildMojoConfigurationTest extends AbstractMSBuildMojoTestCase
                 outputStream.toString().contains( "/maxcpucount:4 " ) );
     }
 
+    @Test
+    public final void testMaxCpuCount0Configuration() throws Exception
+    {
+        MSBuildMojo msbuildMojo = ( MSBuildMojo ) lookupConfiguredMojo( MSBuildMojo.MOJO_NAME, 
+                "/unit/configurations/minimal-solution-with-maxcpucount-zero-pom.xml" );
+        
+        msbuildMojo.execute();
+        
+        assertFalse( "MSBuild command line error /maxcpucount found",
+                outputStream.toString().contains( "/maxcpucount" ) );
+    }
+    
     private PrintStream stdout;
     private ByteArrayOutputStream outputStream;
 }

--- a/msbuild-maven-plugin/src/test/resources/unit/configurations/minimal-solution-with-maxcpucount-zero-pom.xml
+++ b/msbuild-maven-plugin/src/test/resources/unit/configurations/minimal-solution-with-maxcpucount-zero-pom.xml
@@ -1,0 +1,38 @@
+<!--
+   Copyright 2013 Andrew Everitt, Andrew Heckford, Daniele Masato
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <groupId>uk.org.raje.maven.plugins.unit</groupId>
+    <artifactId>minimal-solution-with-maxcpucount-configuration</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>msbuild-solution</packaging>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>uk.org.raje.maven.plugins</groupId>
+                <artifactId>msbuild-maven-plugin</artifactId>
+                <configuration>
+                    <msbuildPath>${basedir}/src/test/resources/unit/configurations/test-msbuild.cmd</msbuildPath>
+                    <msbuildMaxCpuCount>0</msbuildMaxCpuCount>
+                    <projectFile>${basedir}/src/test/resources/unit/configurations/configurations-test.sln</projectFile>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/msbuild-maven-plugin/src/test/resources/unit/configurations/test-msbuild.sh
+++ b/msbuild-maven-plugin/src/test/resources/unit/configurations/test-msbuild.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+SCRIPT_DIR=`dirname $0`
+if [ -d $SCRIPT_DIR/Release ]; then
+	rm -rf $SCRIPT_DIR/Release
+fi
+mkdir $SCRIPT_DIR/Release
+echo FAKE FILE > $SCRIPT_DIR/Release/configurations-test.exe
+echo FAKE FILE > $SCRIPT_DIR/Release/configurations-test.dll
+echo FAKE FILE > $SCRIPT_DIR/Release/configurations-test.lib
+if [ -d $SCRIPT_DIR/Debug ]; then
+	rm -rf $SCRIPT_DIR/Debug
+fi
+mkdir $SCRIPT_DIR/Debug
+echo FAKE FILE > $SCRIPT_DIR/Debug/configurations-test.exe
+echo FAKE FILE > $SCRIPT_DIR/Debug/configurations-test.dll
+echo FAKE FILE > $SCRIPT_DIR/Debug/configurations-test.lib
+
+echo "$@"


### PR DESCRIPTION
.Net Framework 2.0 msbuild doesn't support /maxcpucount param. Quick fix is to add an if to disable /maxcpucount argument when maxcpucount < 0 (and not -1)